### PR TITLE
Resolve runtime error RedisArray

### DIFF
--- a/src/Vetruvet/PhpRedis/Database.php
+++ b/src/Vetruvet/PhpRedis/Database.php
@@ -3,6 +3,7 @@
 namespace Vetruvet\PhpRedis;
 
 use \Redis;
+use \RedisArray;
 
 class Database extends \Illuminate\Redis\Database {
 


### PR DESCRIPTION
If I'm trying to use `cluster = true`  i got a runtime exception.

`use \RedisArray;`
resolves the issue
