### PR TITLE
Adds Redis authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ All options are optional, you can specify an empty array to get the default conn
     'default' => array(
         'host'       => '127.0.0.1', // default: '127.0.0.1'
         'port'       => 6379,        // default: 6379
+        'password'   => password     // default: null
         'prefix'     => 'myapp:',    // default: ''
         'database'   => 7,           // default: 0
         'timeout'    => 0.5,         // default: 0 (no timeout)

--- a/src/Vetruvet/PhpRedis/Database.php
+++ b/src/Vetruvet/PhpRedis/Database.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace Vetruvet\PhpRedis;
 
@@ -41,6 +41,7 @@ class Database extends \Illuminate\Redis\Database {
             }
 
             $cluster[$host.':'.$port] = array(
+                'password'   => empty($server['password']) ? '' : $server['password'],
             	'prefix'     => empty($server['prefix'])   ? '' : $server['prefix'],
             	'database'   => empty($server['database']) ? 0  : $server['database'],
             	'serializer' => $serializer,
@@ -61,9 +62,10 @@ class Database extends \Illuminate\Redis\Database {
 
         foreach ($cluster as $host => $options) {
         	$redis = $ra->_instance($host);
-        	$redis->setOption(Redis::OPT_PREFIX, $options['prefix']);
-        	$redis->setOption(Redis::OPT_SERIALIZER, $options['serializer']);
-        	$redis->select($options['database']);
+            $redis->setOption(Redis::OPT_PREFIX, $options['prefix']);
+            $redis->setOption(Redis::OPT_SERIALIZER, $options['serializer']);
+            $redis->auth($options['password']);
+            $redis->select($options['database']);
         }
 
         return array('default' => $ra);
@@ -95,6 +97,10 @@ class Database extends \Illuminate\Redis\Database {
 
             if (!empty($server['prefix'])) {
             	$redis->setOption(Redis::OPT_PREFIX, $server['prefix']);
+            }
+
+            if (!empty($server['password'])) {
+                $redis->auth($server['password']);
             }
 
             if (!empty($server['database'])) {


### PR DESCRIPTION
This change implements a call to the AUTH command in Redis in order to support instances that explicitly require authentication. Follows the existing PRedis implementation.
